### PR TITLE
release 5.3.0 with our patches

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,8 @@ npm-debug.log
 build/
 .DS_Store
 package-lock.json
+yarn-error.log
+a.out
 
 # Keep bundled code out of Git
 dist/

--- a/.replit
+++ b/.replit
@@ -1,0 +1,29 @@
+# compile = "./.config/build.sh"
+run = "yarn start"
+entrypoint = "index.ts"
+hidden = [".build", ".config"]
+
+[packager]
+language = "nodejs"
+
+[packager.features]
+enabledForHosting = false
+packageSearch = true
+guessImports = true
+
+[env]
+XDG_CONFIG_HOME = "/home/runner/.config"
+
+[nix]
+channel = "stable-22_11"
+
+[gitHubImport]
+requiredFiles = [".replit", "replit.nix", ".config"]
+
+[languages]
+
+[languages.typescript]
+pattern = "**/{*.ts,*.js,*.tsx,*.jsx}"
+
+[languages.typescript.languageServer]
+start = "typescript-language-server --stdio"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@replit/xterm",
   "description": "Full xterm terminal, in your browser",
-  "version": "5.3.0",
+  "version": "5.3.0-patched.2",
   "main": "lib/xterm.js",
   "style": "css/xterm.css",
   "types": "typings/xterm.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "xterm",
+  "name": "@replit/xterm",
   "description": "Full xterm terminal, in your browser",
   "version": "5.3.0",
   "main": "lib/xterm.js",

--- a/replit.nix
+++ b/replit.nix
@@ -1,0 +1,31 @@
+{ pkgs }: {
+    deps = [
+        pkgs.yarn
+        pkgs.esbuild
+        pkgs.nodejs-16_x
+
+        pkgs.nodePackages.typescript
+        pkgs.nodePackages.typescript-language-server
+
+        # For some reason this expects python
+        pkgs.python310Full
+        pkgs.replitPackages.prybar-python310
+        pkgs.replitPackages.stderred
+    ];
+    env = {
+      PYTHON_LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath [
+        # Needed for pandas / numpy
+        pkgs.stdenv.cc.cc.lib
+        pkgs.zlib
+        # Needed for pygame
+        pkgs.glib
+        # Needed for matplotlib
+        pkgs.xorg.libX11
+      ];
+      PYTHONHOME = "${pkgs.python310Full}";
+      PYTHONBIN = "${pkgs.python310Full}/bin/python3.10";
+      LANG = "en_US.UTF-8";
+      STDERREDBIN = "${pkgs.replitPackages.stderred}/bin/stderred";
+      PRYBAR_PYTHON_BIN = "${pkgs.replitPackages.prybar-python310}/bin/prybar-python310";
+    };
+}

--- a/src/browser/input/CompositionHelper.test.ts
+++ b/src/browser/input/CompositionHelper.test.ts
@@ -58,7 +58,7 @@ describe('CompositionHelper', () => {
           // Second character 'ㅇ'
           compositionHelper.compositionstart();
           compositionHelper.compositionupdate({ data: 'ㅇ' });
-          textarea.value = 'ㅇㅇ';
+          textarea.value = 'ㅇ';
           setTimeout(() => { // wait for any textarea updates
             compositionHelper.compositionend();
             setTimeout(() => { // wait for any textarea updates
@@ -76,10 +76,11 @@ describe('CompositionHelper', () => {
       compositionHelper.compositionupdate({ data: 'ㅇ' });
       textarea.value = 'ㅇ';
       setTimeout(() => { // wait for any textarea updates
-        compositionHelper.compositionupdate({ data: '아' });
+        compositionHelper.compositionupdate({ data: 'ㅏ' });
         textarea.value = '아';
+        console.log(textarea.value);
         setTimeout(() => { // wait for any textarea updates
-          compositionHelper.compositionupdate({ data: '앙' });
+          compositionHelper.compositionupdate({ data: 'ㅇ' });
           textarea.value = '앙';
           setTimeout(() => { // wait for any textarea updates
             compositionHelper.compositionend();
@@ -88,13 +89,13 @@ describe('CompositionHelper', () => {
               // Second character '앙'
               compositionHelper.compositionstart();
               compositionHelper.compositionupdate({ data: 'ㅇ' });
-              textarea.value = '앙ㅇ';
+              textarea.value = 'ㅇ';
               setTimeout(() => { // wait for any textarea updates
-                compositionHelper.compositionupdate({ data: '아' });
-                textarea.value = '앙아';
+                compositionHelper.compositionupdate({ data: 'ㅏ' });
+                textarea.value = '아';
                 setTimeout(() => { // wait for any textarea updates
-                  compositionHelper.compositionupdate({ data: '앙' });
-                  textarea.value = '앙앙';
+                  compositionHelper.compositionupdate({ data: 'ㅇ' });
+                  textarea.value = '앙';
                   setTimeout(() => { // wait for any textarea updates
                     compositionHelper.compositionend();
                     setTimeout(() => { // wait for any textarea updates
@@ -116,22 +117,25 @@ describe('CompositionHelper', () => {
       compositionHelper.compositionupdate({ data: 'ㅇ' });
       textarea.value = 'ㅇ';
       setTimeout(() => { // wait for any textarea updates
-        compositionHelper.compositionupdate({ data: '아' });
+        compositionHelper.compositionupdate({ data: 'ㅏ' });
         textarea.value = '아';
         setTimeout(() => { // wait for any textarea updates
           // Start second character '아' in first character
-          compositionHelper.compositionupdate({ data: '앙' });
+          compositionHelper.compositionupdate({ data: 'ㅇ' });
           textarea.value = '앙';
           setTimeout(() => { // wait for any textarea updates
             compositionHelper.compositionend();
-            compositionHelper.compositionstart();
-            compositionHelper.compositionupdate({ data: '아' });
-            textarea.value = '아아';
-            setTimeout(() => { // wait for any textarea updates
-              compositionHelper.compositionend();
+            setTimeout(() => {
+              assert.equal(handledText, '앙');
+              compositionHelper.compositionstart();
+              compositionHelper.compositionupdate({ data: '아' });
+              textarea.value = '아';
               setTimeout(() => { // wait for any textarea updates
-                assert.equal(handledText, '아아');
-                done();
+                compositionHelper.compositionend();
+                setTimeout(() => { // wait for any textarea updates
+                  assert.equal(handledText, '앙아');
+                  done();
+                }, 0);
               }, 0);
             }, 0);
           }, 0);

--- a/src/browser/input/CompositionHelper.ts
+++ b/src/browser/input/CompositionHelper.ts
@@ -169,6 +169,7 @@ export class CompositionHelper {
           }
           if (input.length > 0) {
             this._coreService.triggerDataEvent(input, true);
+            this._textarea.value = '';
           }
         }
       }, 0);

--- a/src/browser/services/RenderService.ts
+++ b/src/browser/services/RenderService.ts
@@ -203,11 +203,14 @@ export class RenderService extends Disposable implements IRenderService {
 
   public setRenderer(renderer: IRenderer): void {
     this._renderer.value = renderer;
-    this._renderer.value.onRequestRedraw(e => this.refreshRows(e.start, e.end, true));
+    // If the value was not set, the terminal is being disposed so ignore it
+    if (this._renderer.value) {
+      this._renderer.value.onRequestRedraw(e => this.refreshRows(e.start, e.end, true));
 
-    // Force a refresh
-    this._needsSelectionRefresh = true;
-    this._fullRefresh();
+      // Force a refresh
+      this._needsSelectionRefresh = true;
+      this._fullRefresh();
+    }
   }
 
   public addRefreshCallback(callback: FrameRequestCallback): number {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,66 @@
+{
+	"compilerOptions": {
+		/* Visit https://aka.ms/tsconfig.json to read more about this file */
+		/* Basic Options */
+		// "incremental": true,                         /* Enable incremental compilation */
+		"target": "ESNEXT", /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', 'ES2021', or 'ESNEXT'. */
+		"module": "ESNext", /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */
+		// "lib": [],                                   /* Specify library files to be included in the compilation. */
+		// "allowJs": true,                             /* Allow javascript files to be compiled. */
+		// "checkJs": true,                             /* Report errors in .js files. */
+		// "jsx": "preserve",                           /* Specify JSX code generation: 'preserve', 'react-native', 'react', 'react-jsx' or 'react-jsxdev'. */
+		// "declaration": true,                         /* Generates corresponding '.d.ts' file. */
+		// "declarationMap": true,                      /* Generates a sourcemap for each corresponding '.d.ts' file. */
+		// "sourceMap": true,                           /* Generates corresponding '.map' file. */
+		// "outFile": "./",                             /* Concatenate and emit output to single file. */
+		// "outDir": "./",                              /* Redirect output structure to the directory. */
+		// "rootDir": "./",                             /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
+		// "composite": true,                           /* Enable project compilation */
+		// "tsBuildInfoFile": "./",                     /* Specify file to store incremental compilation information */
+		// "removeComments": true,                      /* Do not emit comments to output. */
+		"noEmit": true,                              /* Do not emit outputs. */
+		// "importHelpers": true,                       /* Import emit helpers from 'tslib'. */
+		// "downlevelIteration": true,                  /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
+		// "isolatedModules": true,                     /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
+		/* Strict Type-Checking Options */
+		"strict": true, /* Enable all strict type-checking options. */
+		// "noImplicitAny": true,                       /* Raise error on expressions and declarations with an implied 'any' type. */
+		// "strictNullChecks": true,                    /* Enable strict null checks. */
+		// "strictFunctionTypes": true,                 /* Enable strict checking of function types. */
+		// "strictBindCallApply": true,                 /* Enable strict 'bind', 'call', and 'apply' methods on functions. */
+		// "strictPropertyInitialization": true,        /* Enable strict checking of property initialization in classes. */
+		// "noImplicitThis": true,                      /* Raise error on 'this' expressions with an implied 'any' type. */
+		// "alwaysStrict": true,                        /* Parse in strict mode and emit "use strict" for each source file. */
+		/* Additional Checks */
+		// "noUnusedLocals": true,                      /* Report errors on unused locals. */
+		// "noUnusedParameters": true,                  /* Report errors on unused parameters. */
+		// "noImplicitReturns": true,                   /* Report error when not all code paths in function return a value. */
+		// "noFallthroughCasesInSwitch": true,          /* Report errors for fallthrough cases in switch statement. */
+		// "noUncheckedIndexedAccess": true,            /* Include 'undefined' in index signature results */
+		// "noImplicitOverride": true,                  /* Ensure overriding members in derived classes are marked with an 'override' modifier. */
+		// "noPropertyAccessFromIndexSignature": true,  /* Require undeclared properties from index signatures to use element accesses. */
+		/* Module Resolution Options */
+		"moduleResolution": "node", /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+		// "baseUrl": "./",                             /* Base directory to resolve non-absolute module names. */
+		// "paths": {},                                 /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
+		// "rootDirs": [],                              /* List of root folders whose combined content represents the structure of the project at runtime. */
+		"typeRoots": [
+			"./node_modules/@types",
+		], /* List of folders to include type definitions from. */
+		// "types": [],                                 /* Type declaration files to be included in compilation. */
+		// "allowSyntheticDefaultImports": true,        /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
+		"esModuleInterop": true, /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+		// "preserveSymlinks": true,                    /* Do not resolve the real path of symlinks. */
+		// "allowUmdGlobalAccess": true,                /* Allow accessing UMD globals from modules. */
+		/* Experimental Options */
+		// "experimentalDecorators": true,              /* Enables experimental support for ES7 decorators. */
+		// "emitDecoratorMetadata": true,               /* Enables experimental support for emitting type metadata for decorators. */
+		/* Advanced Options */
+		"skipLibCheck": true, /* Skip type checking of declaration files. */
+		"forceConsistentCasingInFileNames": true /* Disallow inconsistently-cased references to the same file. */
+	},
+	"exclude": [
+		"node_modules",
+		".build"
+	]
+}


### PR DESCRIPTION
This branch is checked out at a commit that was made with `5.3.0` release on official `xterm.js` repo: https://github.com/xtermjs/xterm.js/commit/2e02c37e528c1abc200ce401f49d0d7eae330e63

This branch also contains all of our patches.

The release process is as follows:

1. use node 18
2. run:

    ```bash
     yarn --frozen-lockfile
     yarn setup
     yarn package
     ```
3. and finally `npm login && npm publish`

We originally published `@replit/xterm.js` version `5.3.0` from `master` which is a bunch of commits ahead of this one, and introduces a bug with unicode. I unpublished that version, and will re-publish this as `5.3.0` on Monday (need to wait 24h for `npm` to allow us to publish the same package version again, for whatever reason).

---

EDIT: after testing, I also had to pull in https://github.com/xtermjs/xterm.js/pull/4785 as it fixes an issue with `Cannot read properties of undefined (reading 'onRequestRedraw')` which we started getting when disposing shell/console. This patch will land with `5.4.0` which is in beta right now.

I also decided to call our version `{x}.{y}.{z}-patched.{num}` so it's bit clearer what we're doing, and we can keep updating the `num` without having to bump minor/patch number.